### PR TITLE
Add Flask keepalive server

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,8 @@ import feedparser
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from flask import Flask
+from threading import Thread
 
 # Logging
 logging.basicConfig(
@@ -28,6 +30,15 @@ enviados_clima = set()
 enviados_noticias = set()
 enviados_alertas = set()
 enviados_partidos = set()
+
+flask_app = Flask(__name__)
+
+@flask_app.route("/")
+def raiz():
+    return "Bot funcionando"
+
+def iniciar_flask():
+    flask_app.run(host="0.0.0.0", port=8080)
 
 def obtener_clima():
     try:
@@ -89,4 +100,5 @@ async def iniciar_bot():
     await app.run_polling()
 
 if __name__ == "__main__":
+    Thread(target=iniciar_flask, daemon=True).start()
     asyncio.run(iniciar_bot())


### PR DESCRIPTION
## Summary
- run a small Flask server so Render keeps the Telegram bot alive
- start Flask in a separate thread

## Testing
- `python -m py_compile bot.py`
- `git push origin main` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_685aec53371c832f89f386635d72e6ab