### PR TITLE
Fix scheduler async warning

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -93,7 +93,7 @@ async def iniciar_bot():
 
     tz = pytz.timezone("America/Argentina/Buenos_Aires")
     scheduler = AsyncIOScheduler(timezone=tz)
-    scheduler.add_job(lambda: asyncio.create_task(resumen_periodico(app)), 'interval', minutes=1)
+    scheduler.add_job(resumen_periodico, 'interval', minutes=1, args=[app])
     scheduler.start()
 
     print("✅ BOT FUNCIONANDO CORRECTAMENTE")


### PR DESCRIPTION
## Summary
- ensure `resumen_periodico` coroutine is awaited by `AsyncIOScheduler`

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685af4dd93dc832f8b422ca88fc9b014