### PR TITLE
Evitar que Render duerma el bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Bot automático para Telegram. Informa clima, noticias destacadas (policiales, p
 
 Este proyecto está diseñado para ejecutarse en **Python 3.10**. Render usa el
 archivo `runtime.txt` para fijar la versión `python-3.10.13`.
+
+El bot utiliza **APScheduler** para ejecutar tareas automáticas y se auto-
+envía un `ping` cada 14 minutos a la ruta `/ping` para evitar que Render
+detenga el contenedor en el plan gratuito.


### PR DESCRIPTION
## Summary
- implement keep-alive endpoint and periodic self-ping
- document Render keep-alive strategy

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685beed04b4c832f8c8bc3af8d105e5b