### PR TITLE
Mejora total del bot: alertas AMBA, River, clima, cortes de tránsito, keep-alive y rutas Ezeiza

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Bot automático para Telegram. Informa clima, noticias destacadas (policiales, p
 /clima     - Clima y alertas actuales
 /noticias  - Últimas noticias
 /river     - Partido de River del día
+/alertas   - Ver alertas activas
+/ruta      - Tr\u00e1nsito a Ezeiza
 /resumen   - Resumen completo
 /ayuda     - Esta ayuda
 ```
@@ -22,6 +24,9 @@ archivo `runtime.txt` para fijar la versión `python-3.10.13`.
 El bot utiliza **APScheduler** para ejecutar tareas automáticas y se auto-
 envía un `ping` cada 14 minutos a la ruta `/ping` para evitar que Render
 detenga el contenedor en el plan gratuito.
+
+Además revisa alertas meteorológicas y noticias urgentes (accidentes,
+guerra, cortes de tránsito) para enviarlas al instante.
 
 Además detecta alertas meteorológicas nuevas y noticias urgentes con palabras
 clave (asalto, tiroteo, guerra, etc.) para enviarlas inmediatamente al chat.


### PR DESCRIPTION
## Summary
- ampliar ciudades monitoreadas y agregar feeds internacionales
- añadir keywords urgentes y nuevo comando `/ruta`
- generar endpoint `/ping` que devuelve `pong`
- avisar rutas a Ezeiza y programar envíos diarios
- actualizar ayuda y README

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685bf4bdc3a4832fa192ce7965331202