### PR TITLE
Fix errores: ajustes en comandos, cron, alertas o integración Twitter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -98,6 +98,7 @@ KEYWORDS_URGENTES = [
     "25 de mayo",
     "corte",
     "congestion",
+    "river vs",
 ]
 
 
@@ -167,7 +168,7 @@ def consultar_alertas() -> dict[str, list[str]]:
                 resultados[nombre] = eventos
         except Exception as e:  # pragma: no cover - red de terceros
             logging.error(f"[ALERTAS {nombre}] {e}")
-            return None
+            continue
     return resultados
 
 
@@ -244,6 +245,8 @@ def obtener_ruta() -> str:
 async def revisar_alertas_urgentes(app):
     """Env\u00eda mensaje si aparece una alerta meteorol\u00f3gica nueva."""
     datos = consultar_alertas()
+    if not datos:
+        return
     nuevos: list[str] = []
     for ciudad, eventos in datos.items():
         for ev in eventos:


### PR DESCRIPTION
## Summary
- add `river vs` keyword to urgent alerts
- avoid failing `consultar_alertas` on single city errors
- skip processing alerts if no data returned

## Testing
- `python -m py_compile bot.py`
- `python - <<'PY'
import bot
print('clima snippet:', bot.obtener_clima()[:20])
print('alertas snippet:', bot.obtener_alertas())
print('noticias snippet:', bot.obtener_noticias(bot.RSS_POLICIALES))
print('partido snippet:', bot.obtener_partido_river())
print('ruta snippet:', bot.obtener_ruta())
PY`

------
https://chatgpt.com/codex/tasks/task_e_685bfaf829fc832f8a0923e8a23db743