### PR TITLE
Fix timezone in /river command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 
 import feedparser
@@ -218,7 +218,7 @@ def obtener_partido_river() -> str | None:
             fecha: datetime | None = None
             if entry.get("published_parsed"):
                 fecha = (
-                    datetime(*entry.published_parsed[:6], tzinfo=pytz.utc)
+                    datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
                     .astimezone(tz)
                 )
             elif entry.get("published"):

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -1,0 +1,27 @@
+import types
+from datetime import datetime
+import os
+import sys
+import pytz
+import feedparser
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import bot
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2025,6,25,12,0,0, tzinfo=tz)
+
+def test_river_juega_hoy(monkeypatch):
+    entry = feedparser.FeedParserDict({
+        'title': 'River vs Boca',
+        'published_parsed': pytz.utc.localize(datetime(2025,6,26,1,0,0)).timetuple(),
+    })
+
+    def fake_parse(url):
+        return types.SimpleNamespace(entries=[entry])
+
+    monkeypatch.setattr(feedparser, 'parse', fake_parse)
+    monkeypatch.setattr(bot, 'datetime', FixedDateTime)
+
+    assert bot.obtener_partido_river() == '🏟 River juega hoy vs Boca a las 22:00'


### PR DESCRIPTION
## Summary
- fix timezone conversion when reading River matches
- add regression test for River match at 22:00 local time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c00dd0dcc832f98280cea96883787