### PR TITLE
Add river_juega_hoy using Promiedos RSS

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -322,6 +322,23 @@ def _parse_river_html(html: str, now: datetime) -> tuple[str | None, datetime | 
     return rival, fecha, raw_date, torneo
 
 
+def river_juega_hoy():
+    try:
+        zona_horaria_ar = pytz.timezone('America/Argentina/Buenos_Aires')
+        hoy = datetime.now(zona_horaria_ar).date()
+        url = 'https://www.promiedos.com.ar/rss/futbol-primera'
+        feed = feedparser.parse(url)
+        for entrada in feed.entries:
+            titulo = entrada.title.lower()
+            fecha_evento = entrada.published_parsed
+            fecha_evento = datetime(*fecha_evento[:6]).date()
+            if "river" in titulo and fecha_evento == hoy:
+                return f"🎯 Hoy juega River: {entrada.title}"
+        return "⚽ Hoy NO juega River Plate."
+    except Exception as e:
+        return f"❌ Error al buscar si juega River: {str(e)}"
+
+
 def obtener_partido_river(debug: bool = False) -> str | None:
     """Devuelve información del partido de River si se juega hoy."""
     try:
@@ -575,7 +592,7 @@ def armar_resumen() -> str:
     if internacional:
         partes.append("🌎 *Internacional:*\n" + internacional)
 
-    partido = obtener_partido_river()
+    partido = river_juega_hoy()
     if partido:
         partes.append(partido)
 
@@ -644,7 +661,7 @@ async def comando_noticias(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 async def comando_river(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Informa si River juega hoy y resultado si está disponible."""
     try:
-        partido = obtener_partido_river()
+        partido = river_juega_hoy()
         mensaje = partido or "ℹ️ River no tiene partido programado para hoy."
         await update.message.reply_text(
             mensaje,

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 import types
 
-import requests
+import feedparser
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import bot
@@ -14,12 +14,14 @@ class FixedDateTime(datetime):
         return cls(2025,6,25,12,0,0, tzinfo=tz)
 
 def test_river_juega_hoy(monkeypatch):
-    html = '<div>Liga Profesional - River Plate vs Boca - 25/06 22:00</div>'
+    class Entry:
+        title = 'River Plate vs Boca - 25/06 22:00'
+        published_parsed = datetime(2025,6,25).timetuple()
 
-    class Resp:
-        text = html
+    class Feed:
+        entries = [Entry()]
 
-    monkeypatch.setattr(requests, 'get', lambda *a, **k: Resp())
+    monkeypatch.setattr(feedparser, 'parse', lambda *a, **k: Feed())
     monkeypatch.setattr(bot, 'datetime', FixedDateTime)
 
-    assert bot.obtener_partido_river() == '🏟 River juega hoy a las 22:00 vs Boca (Liga Profesional)'
+    assert bot.river_juega_hoy() == '🎯 Hoy juega River: River Plate vs Boca - 25/06 22:00'


### PR DESCRIPTION
## Summary
- implement `river_juega_hoy` using feedparser and Promiedos RSS
- include River info in summary and /river command
- update tests to cover new function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c31460f9c832f9fa8f85b30b6a33d